### PR TITLE
add Lab0, update markdown for best practices

### DIFF
--- a/Lab0/README.md
+++ b/Lab0/README.md
@@ -1,0 +1,27 @@
+# Lab 0. Set up your kubernetes environment
+
+For the hands-on labs in this tutorial repository, you will need a kubernetes cluster. You can either create one as-a-service from the IBM Cloud Kubernetes Service, use a hosted environment or install one locally on your workstation.
+
+## Use the IBM Cloud Kubernetes Service
+
+You will need either a paid IBM Cloud account or an IBM Cloud account which is a Trial account (not a Lite account). If you have one of these accounts, use the [Getting Started Guide](https://cloud.ibm.com/docs/containers?topic=containers-getting-started) to create your cluster.
+
+## Use a hosted trial environment
+
+There are a few services that are accessible over the Internet for temporary use. As these are free services, they can sometimes experience periods of limited availablity/quality. On the other hand, they can be a quick way to get started!
+
+* [Kubernetes playground on Katacoda](https://www.katacoda.com/courses/kubernetes/playground) This environment starts with a master and worker node pre-configured. You can run the steps from Labs 1 and onward from the master node.
+
+* [Play with Kubernetes](https://labs.play-with-k8s.com/) After signing in with your github or docker hub id, click on **Start**, then **Add New Instance** and follow steps shown in terminal to spin up the cluster and add workers.
+
+## Set up on your own workstation
+
+If you would like to configure kubernetes to run on your local workstation for non-production, learning use, there are several options.
+
+* [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/) This solution requires the installation of a supported VM provider (KVM, VirtualBox, HyperKit, Hyper-V - depending on platform)
+
+* [Kubernetes in Docker (kind)](https://kind.sigs.k8s.io/) Runs a kubernetes cluster on Docker containers
+
+* [Docker Desktop (Mac)](https://docs.docker.com/docker-for-mac/kubernetes/) [Docker Desktop (Windows)](https://docs.docker.com/docker-for-windows/kubernetes/) Docker Desktop includes a kubernetes environment
+
+* [Microk8s](https://microk8s.io/docs/) Installable kubernetes packaged as an Ubuntu `snap` image.

--- a/Lab1/README.md
+++ b/Lab1/README.md
@@ -1,14 +1,9 @@
-# Lab 1. Set up and deploy your first application
+# Lab 1. Deploy your first application
 
 Learn how to deploy an application to a Kubernetes cluster hosted within
 the IBM Container Service.
 
-# 0. Setup
-
-If following this lab as part of an IBM instructor led workshop, please follow these instructions to setup your workshop environment: https://gist.github.com/jzaccone/0cdc321e5dc8adb0dca98ca861284c01
-
-
-# 1. Deploy your application
+## 1. Deploy the guestbook application
 
 In this part of the lab we will deploy an application called `guestbook`
 that has already been built and uploaded to DockerHub under the name
@@ -28,19 +23,19 @@ that has already been built and uploaded to DockerHub under the name
    NAME                          READY     STATUS              RESTARTS   AGE
    guestbook-59bd679fdc-bxdg7    0/1       ContainerCreating   0          1m
    ```
+
    Eventually, the status should show up as `Running`.
-   
+
    ```console
    $ kubectl get pods
    NAME                          READY     STATUS              RESTARTS   AGE
    guestbook-59bd679fdc-bxdg7    1/1       Running             0          1m
    ```
-   
+
    The end result of the run command is not just the pod containing our application containers,
    but a Deployment resource that manages the lifecycle of those pods.
- 
-   
-3. Once the status reads `Running`, we need to expose that deployment as a
+
+1. Once the status reads `Running`, we need to expose that deployment as a
    service so we can access it through the IP of the worker nodes.
    The `guestbook` application listens on port 3000.  Run:
 
@@ -49,34 +44,34 @@ that has already been built and uploaded to DockerHub under the name
    service "guestbook" exposed
    ```
 
-4. To find the port used on that worker node, examine your new service:
+1. To find the port used on that worker node, examine your new service:
 
    ```console
    $ kubectl get service guestbook
    NAME        TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
    guestbook   NodePort   10.10.10.253   <none>        3000:31208/TCP   1m
    ```
-   
+
    We can see that our `<nodeport>` is `31208`. We can see in the output the port mapping from 3000 inside 
    the pod exposed to the cluster on port 31208. This port in the 31000 range is automatically chosen, 
    and could be different for you.
 
-5. `guestbook` is now running on your cluster, and exposed to the internet. We need to find out where it is accessible.
+1. `guestbook` is now running on your cluster, and exposed to the internet. We need to find out where it is accessible.
    The worker nodes running in the container service get external IP addresses.
    Get the workers for your cluster and note one (any one) of the public IPs listed on the `<public-IP>` line.
-   
+
    ```console
    $ ibmcloud ks workers $USERNAME-cluster
    OK
    ID                                                 Public IP        Private IP     Machine Type   State    Status   Zone    Version  
    kube-hou02-pa1e3ee39f549640aebea69a444f51fe55-w1   173.193.99.136   10.76.194.30   free           normal   Ready    hou02   1.5.6_1500*
    ```
-   
+
    We can see that our `<public-IP>` is `173.193.99.136`.
-   
-6. Now that you have both the address and the port, you can now access the application in the web browser
+
+1. Now that you have both the address and the port, you can now access the application in the web browser
    at `<public-IP>:<nodeport>`. In the example case this is `173.193.99.136:31208`.
-   
+
 Congratulations, you've now deployed an application to Kubernetes!
 
 When you're all done, continue to the

--- a/Lab2/README.md
+++ b/Lab2/README.md
@@ -2,7 +2,7 @@
 
 In this lab, you'll learn how to update the number of instances
 a deployment has and how to safely roll out an update of your application
-on Kubernetes. 
+on Kubernetes.
 
 For this lab, you need a running deployment of the `guestbook` application
 from the previous lab. If you deleted it, recreate it using:
@@ -10,8 +10,8 @@ from the previous lab. If you deleted it, recreate it using:
 ```console
 $ kubectl run guestbook --image=ibmcom/guestbook:v1
 ```
-    
-# 1. Scale apps with replicas
+
+## 1. Scale apps with replicas
 
 A *replica* is a copy of a pod that contains a running service. By having
 multiple replicas of a pod, you can ensure your deployment has the available
@@ -30,7 +30,7 @@ resources to handle increasing load on your application.
    10 replicas by starting 9 new pods with the same configuration as
    the first.
 
-4. To see your changes being rolled out, you can run:
+1. To see your changes being rolled out, you can run:
    `kubectl rollout status deployment guestbook`.
 
    The rollout might occur so quickly that the following messages might
@@ -50,7 +50,7 @@ resources to handle increasing load on your application.
    deployment "guestbook" successfully rolled out
    ```
 
-5. Once the rollout has finished, ensure your pods are running by using:
+1. Once the rollout has finished, ensure your pods are running by using:
    `kubectl get pods`.
 
    You should see output listing 10 replicas of your deployment:
@@ -76,7 +76,7 @@ to your deployment, as shown in the following diagram:
 
 ![HA with more clusters and regions](../images/cluster_ha_roadmap.png)
 
-# 2. Update and roll back apps
+## 2. Update and roll back apps
 
 Kubernetes allows you to do rolling upgrade of your application to a new
 container image. This allows you to easily update the running image and also allows you to
@@ -86,6 +86,7 @@ In the previous lab, we used an image with a `v1` tag. For our upgrade
 we'll use the image with the `v2` tag.
 
 To update and roll back:
+
 1. Using `kubectl`, you can now update your deployment to use the
    `v2` image. `kubectl` allows you to change details about existing
    resources with the `set` subcommand. We can use it to change the
@@ -99,7 +100,7 @@ To update and roll back:
    Multiple containers can be updated at the same time.
    ([More information](https://kubernetes.io/docs/user-guide/kubectl/kubectl_set_image/).)
 
-3. Run `kubectl rollout status deployment/guestbook` to check the status of
+1. Run `kubectl rollout status deployment/guestbook` to check the status of
    the rollout. The rollout might occur so quickly that the following messages
    might _not_ display:
 
@@ -140,7 +141,7 @@ To update and roll back:
    deployment "guestbook" successfully rolled out
    ```
 
-4. Test the application as before, by accessing `<public-IP>:<nodeport>` 
+1. Test the application as before, by accessing `<public-IP>:<nodeport>` 
    in the browser to confirm your new code is active.
 
    Remember, to get the "nodeport" and "public-ip" use:
@@ -152,7 +153,8 @@ To update and roll back:
    To verify that you're running "v2" of guestbook, look at the title of the page,
    it should now be `Guestbook - v2`. If you are using a browser, make sure you force refresh (invalidating your cache).
 
-5. If you want to undo your latest rollout, use:
+1. If you want to undo your latest rollout, use:
+
    ```console
    $ kubectl rollout undo deployment guestbook
    deployment "guestbook"
@@ -160,13 +162,14 @@ To update and roll back:
 
    You can then use `kubectl rollout status deployment/guestbook` to see
    the status.
-   
-6. When doing a rollout, you see references to *old* replicas and *new* replicas.
+
+1. When doing a rollout, you see references to *old* replicas and *new* replicas.
    The *old* replicas are the original 10 pods deployed when we scaled the application.
    The *new* replicas come from the newly created pods with the different image.
    All of these pods are owned by the Deployment.
    The deployment manages these two sets of pods with a resource called a ReplicaSet.
    We can see the guestbook ReplicaSets with:
+
    ```console
    $ kubectl get replicasets -l run=guestbook
    NAME                   DESIRED   CURRENT   READY     AGE
@@ -182,4 +185,4 @@ a different way to achieve the same results:
  To remove the service, use `kubectl delete service guestbook`.
 
 Congratulations! You deployed the second version of the app. Lab 2
-is now complete.
+is now complete. Continue to the [next lab of this course](../Lab3/README.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# IBM Cloud Container Service Lab. 
+# IBM Cloud Container Service Lab
 
 <img src="https://kubernetes.io/images/favicon.png" width="200">
 
-#  Lab overview
+## Lab overview
+
+[Lab 0](Lab0): Setup - if you do now have access to a kubernetes environment, follow the suggestions here to get one. If you are in an IBM workshop and have already signed in to your kubernetes cluster, skip this lab and start with [Lab 1](Lab1).
 
 [Lab 1](Lab1): This lab walks through creating and deploying a simple "guestbook" app written in Go as a net/http Server and accessing it.
 
 [Lab 2](Lab2): Builds on lab 1 to expand to a more resilient setup which can survive having containers fail and recover. Lab 2 will also walk through basic services you need to get started with Kubernetes and the IBM Cloud Container Service
 
+[Lab 3](Lab3): Introduces configuration files used to describe deployments and services and their use to deploy an application.


### PR DESCRIPTION
Remove link to client-specific setup gist in Lab 1. Update main readme to direct users to Lab 0 for setup if they don't have a cluster, otherwise have users who have already have access to k8s for workshop to Lab 1